### PR TITLE
Log Level Option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       id: install
       run: poetry install
 
+    - name: Run comeit Sanity
+      run: poetry run comeit --help
+
     - name: Run Comeit
       if: steps.install.outcome == 'success'
       run: |

--- a/comeit/__init__.py
+++ b/comeit/__init__.py
@@ -1,6 +1,7 @@
 from .checks.body import Body
 from .checks.footer import Footer
 from .checks.header import Header
+from .logger import LogLevel, configure_logger
 from .rules.rule import Component, Rule, Severity
 from .rules.rule_creator import RuleCreator
 from .rules.rule_loader import RuleConfig, RuleLoader
@@ -18,4 +19,6 @@ __all__ = [
     Rule.__name__,
     Component.__name__,
     Severity.__name__,
+    LogLevel.__name__,
+    configure_logger.__name__,
 ]

--- a/comeit/__main__.py
+++ b/comeit/__main__.py
@@ -13,6 +13,7 @@ from comeit import (
     RuleCreator,
     RuleLoader,
     RuleManager,
+    configure_logger,
 )
 from comeit.parse_args import parse_args
 
@@ -89,13 +90,9 @@ def commit_parser():
     """Parse out header, body and footer."""
 
 
-def configure_logger():
-    logging.basicConfig(level=logging.DEBUG)
-
-
 def main():
     args = parse_args()
-    configure_logger()
+    configure_logger(log_level=args.log_level)
 
     logger.info("Creating allowed commit types...")
     allowed_commit_types = create_commit_types()

--- a/comeit/logger.py
+++ b/comeit/logger.py
@@ -1,0 +1,39 @@
+import logging
+from enum import IntEnum
+
+
+class LogLevel(IntEnum):
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    CRITICAL = logging.CRITICAL
+
+    def is_debug(self):
+        return self == LogLevel.DEBUG
+
+    def is_info(self):
+        return self == LogLevel.INFO
+
+    def is_warning(self):
+        return self == LogLevel.WARNING
+
+    def is_error(self):
+        return self == LogLevel.ERROR
+
+    def is_critical(self):
+        return self == LogLevel.CRITICAL
+
+    def __str__(self):
+        return self.name
+
+    @staticmethod
+    def from_string(level_str):
+        try:
+            return LogLevel[level_str.upper()]
+        except KeyError:
+            raise ValueError(f"Invalid log level: {level_str}")
+
+
+def configure_logger(log_level: LogLevel):
+    logging.basicConfig(level=log_level)

--- a/comeit/parse_args.py
+++ b/comeit/parse_args.py
@@ -2,27 +2,31 @@ import argparse
 from dataclasses import dataclass
 from pathlib import Path
 
+from comeit import LogLevel
+
 
 @dataclass
 class ConfigArgs(argparse.Namespace):
     config_file: str
+    log_level: LogLevel
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Process a configuration file.")
 
-    # Define the --config-file argument
     parser.add_argument(
         "--config-file",
         type=Path,
-        help="Path to the configuration file. This file can override the default severity levels"
+        help="Path to the configuration file. This file can override the default severity levels "
         "of rules.",
     )
 
+    parser.add_argument(
+        "--log-level",
+        type=LogLevel.from_string,
+        choices=list(LogLevel),
+        default=LogLevel.WARNING,
+        help="Set the logging level. Defaults to WARNING.",
+    )
+
     return parser.parse_args(namespace=ConfigArgs)
-
-
-if __name__ == "__main__":
-    args = parse_args()
-    # Access the dataclass attributes
-    print(f"Config file path: {args.config_file}")

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,70 @@
+Command Line Interface (CLI)
+============================
+
+This section describes the command-line arguments available for configuring and running the application.
+
+Overview
+--------
+
+The application can be configured through several command-line arguments, allowing customization of logging levels and specifying configuration files.
+
+.. note::
+   The CLI options may change in future versions, so it's always a good idea to check the most up-to-date documentation.
+
+Usage Example
+-------------
+
+Here's an example of how to use the CLI:
+
+.. code-block:: bash
+
+   comeit --config-file path/to/config.yaml --log-level INFO
+
+Arguments
+---------
+
+.. _cli-config-file:
+
+``--config-file``
+   **Type**: :class:`pathlib.Path`
+   
+   Path to the configuration file. This file can override the default severity levels of the rules.
+
+   Example:
+
+   .. code-block:: bash
+
+      comeit --config-file path/to/config.yaml
+
+.. _cli-log-level:
+
+``--log-level``
+   **Type**: :class:`comeit.LogLevel`
+   **Default**: ``WARNING``
+   
+   Set the logging level for the application. You can choose from the following log levels:
+
+   - ``DEBUG``: Detailed information, typically used for debugging.
+   - ``INFO``: General information about the application’s process.
+   - ``WARNING``: Indicates potential issues but not critical.
+   - ``ERROR``: An error that has occurred but does not stop the application.
+   - ``CRITICAL``: Severe errors that may prevent the application from continuing.
+
+   Example:
+
+   .. code-block:: bash
+
+      comeit --log-level DEBUG
+
+Configuration Arguments
+-----------------------
+
+All arguments passed via the command line are encapsulated in the ``ConfigArgs`` dataclass, which stores:
+
+- ``config_file``: A string representing the path to the config file.
+- ``log_level``: The selected log level (``LogLevel`` enum).
+
+Future Updates
+--------------
+
+If the CLI options change in future releases, this document will be updated accordingly. Be sure to check the latest documentation to stay informed of any new options or behavior changes.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,5 +14,6 @@ Lint git commits in a Conventional Commits manner in pure Python.
    :caption: Contents:
 
    get_started
+   cli
    user_config
    rules_config


### PR DESCRIPTION
# Log Level
Adds an option `--log-level` to the cli. This sets the logging of the `comeit` app itself.

## Docs
Added a CLI documentation page in read the docs.

## Integration Tests
Added running `comeit --help` in the integration tests to be able to see the help text of the cli and what options are available.
